### PR TITLE
Make ?release actually restart the bot, and add a daily auto-release

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -50,3 +50,10 @@ INCREMENTING_CHANNEL_ID=XXXXXXXXXX
 
 # The channel that you want to use for announcing emoji changes
 EMOJI_CHANNEL_ID=XXXXXXXXXX
+
+# The channel that ?release gets automatically posted into every morning.
+# Leave unset to disable the automatic release.
+AUTO_RELEASE_CHANNEL_ID=XXXXXXXXXX
+# Cron schedule (default: 8:00 AM daily) and IANA timezone for the above
+AUTO_RELEASE_CRON=0 8 * * *
+AUTO_RELEASE_TZ=America/New_York

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.release-marker.json
 
 built
 db/*

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A basic slackbot built on Node.
 1. If you're running multiple slackbots, rename each one with `$ pm2 restart <id> -n <newname>`.
 1. Your bot should now be able to respond to commands!
 1. To deploy the latest version in production, send the command `?deploy`. Check what version is running with `?version`.
+1. To automatically run `?deploy` every morning (picking up any commits merged to `main` since the last release, e.g. auto-merged Dependabot PRs), set `AUTO_RELEASE_CHANNEL_ID` in `.env` to the channel you want it posted in. Optionally override the time with `AUTO_RELEASE_CRON` (a cron expression, default `0 8 * * *`) and `AUTO_RELEASE_TZ` (an IANA timezone, default `America/New_York`). Leave `AUTO_RELEASE_CHANNEL_ID` unset to disable this.
 
 # APIs
 You should delete the relevant lines from the `.env` file for any APIs you do not wish to use.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,5 +1,12 @@
+const path = require('path');
+
 module.exports = {
   apps: [{
+    // Named after the directory this is cloned into, so each instance keeps
+    // a stable, distinct identity across restarts without manual renaming,
+    // and `pm2 restart ecosystem.config.js` reliably targets the existing
+    // process instead of spawning a duplicate.
+    name: path.basename(__dirname),
     ignore_watch: ['./src'],
     namespace: 'slackbot',
     script: './built/app.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.4.2",
         "finnhub": "^2.0.15",
         "giphy-api": "^2.0.2",
+        "node-cron": "^4.6.0",
         "openai": "^7.0.0",
         "simple-git": "^3.19.1"
       },
@@ -2517,6 +2518,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^17.4.2",
     "finnhub": "^2.0.15",
     "giphy-api": "^2.0.2",
+    "node-cron": "^4.6.0",
     "openai": "^7.0.0",
     "simple-git": "^3.19.1"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,10 @@
 import * as dotenv from 'dotenv'; // see https://github.com/motdotla/dotenv#how-do-i-use-dotenv-with-import
 
 import announceEmojiChange from './emojiChanges';
+import scheduleAutoRelease from './autoRelease';
 import incrementChannelName from './channelIncrementer';
 import { dispatchCommand, dispatchReaction } from './commandDispatcher';
+import { consumeReleaseMarker } from './utils/releaseMarker';
 
 dotenv.config({ quiet: true });
 
@@ -44,7 +46,20 @@ app.event('emoji_changed', async ({ body }) => {
   announceEmojiChange(app, body, process.env.EMOJI_CHANNEL_ID);
 });
 
+scheduleAutoRelease(app);
+
 (async () => {
   await app.start();
   console.log('⚡️ Bolt app is running!');
+
+  // If we just came up from a ?release-triggered rebuild, confirm it here
+  // instead of from the old process, which pm2 likely killed mid-rebuild.
+  const marker = consumeReleaseMarker();
+  if (marker) {
+    await app.client.chat.postMessage({
+      channel: marker.channel,
+      thread_ts: marker.threadTs,
+      text: `Release complete — now running \`${marker.sha}\` (${marker.title}).`,
+    });
+  }
 })();

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,19 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   socketMode: true,
   token: process.env.SLACK_BOT_TOKEN,
+  // Socket mode doesn't listen on any HTTP port by default, so without a
+  // customRoute here, Bolt never starts the underlying server and there's
+  // nothing for an uptime monitor to hit.
+  customRoutes: [
+    {
+      path: '/health',
+      method: ['GET'],
+      handler: (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('ok');
+      },
+    },
+  ],
 });
 
 // Messages that start with ? are interpreted as commands

--- a/src/autoRelease.ts
+++ b/src/autoRelease.ts
@@ -1,0 +1,21 @@
+import cron from 'node-cron';
+
+// Every morning, posts "?release" into the configured channel so the bot
+// picks up any commits (e.g. auto-merged dependabot PRs) merged to main
+// since the last release, exactly as if a human had typed the command.
+const scheduleAutoRelease = (app) => {
+  const channel = process.env.AUTO_RELEASE_CHANNEL_ID;
+
+  if (!channel) {
+    return;
+  }
+
+  const schedule = process.env.AUTO_RELEASE_CRON || '0 8 * * *';
+  const timezone = process.env.AUTO_RELEASE_TZ || 'America/New_York';
+
+  cron.schedule(schedule, () => {
+    app.client.chat.postMessage({ channel, text: '?release' });
+  }, { timezone });
+};
+
+export default scheduleAutoRelease;

--- a/src/commands/rebuild.ts
+++ b/src/commands/rebuild.ts
@@ -2,21 +2,49 @@ import childProcess from 'child_process';
 
 import { respondThreaded } from '../utils/respond';
 
-// Release the slackbot
-const rebuild = async ({ body, say }) => {
-  respondThreaded(say, body, 'Rebuilding... (please wait)');
-  // Give it time to respond before building
-  setTimeout(() => {
-    respondThreaded(say, body, 'Running `npm install`...');
-    const installOut = childProcess.execSync('npm install').toString();
-    respondThreaded(say, body, 'Finished installing! Output:');
-    respondThreaded(say, body, installOut);
+// Runs a build step, reporting its output (or failure) to Slack instead of
+// letting a non-zero exit crash the whole bot process. Returns whether it
+// succeeded.
+const runStep = (say, body, label: string, command: string) => {
+  respondThreaded(say, body, `Running \`${command}\`...`);
 
-    respondThreaded(say, body, 'Running `npm run build`...');
-    const buildOut = childProcess.execSync('npm run build').toString();
-    respondThreaded(say, body, 'Finished building! Output:');
-    respondThreaded(say, body, buildOut);
-  }, 1000);
+  try {
+    const output = childProcess.execSync(command).toString();
+    respondThreaded(say, body, `Finished ${label}! Output:`);
+    if (output.trim()) {
+      respondThreaded(say, body, output);
+    }
+    return true;
+  } catch (error: any) {
+    const details = [error.stdout?.toString(), error.stderr?.toString(), error.message]
+      .filter(Boolean)
+      .join('\n')
+      .slice(-1500);
+    respondThreaded(
+      say,
+      body,
+      `:x: \`${command}\` failed. The bot is still running the previous build.\n\`\`\`${details}\`\`\``,
+    );
+    return false;
+  }
+};
+
+// Rebuilds the slackbot. Resolves to whether the build completed
+// successfully.
+const rebuild = ({ body, say }): Promise<boolean> => {
+  respondThreaded(say, body, 'Rebuilding... (please wait)');
+
+  return new Promise((resolve) => {
+    // Give it time to respond before building
+    setTimeout(() => {
+      if (!runStep(say, body, 'installing', 'npm install')) {
+        resolve(false);
+        return;
+      }
+
+      resolve(runStep(say, body, 'building', 'npm run build'));
+    }, 1000);
+  });
 };
 
 export default rebuild;

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -3,6 +3,7 @@ import { simpleGit } from 'simple-git';
 import childProcess from 'child_process';
 
 import { respondThreaded } from '../utils/respond';
+import { clearReleaseMarker, writeReleaseMarker } from '../utils/releaseMarker';
 import rebuild from './rebuild';
 
 const options = {
@@ -18,31 +19,59 @@ const git = simpleGit(options);
 const release = async ({ body, say }) => {
   respondThreaded(say, body, 'Releasing. Good luck...');
 
-  let out;
-
-  git.pull('origin', 'main', { '--rebase': 'true' }, (err, response) => {
+  git.pull('origin', 'main', { '--rebase': 'true' }, async (err, response) => {
     if (err) {
-      out = 'Something went wrong. I hope you have ssh access.';
-      respondThreaded(say, body, out);
+      console.error('release: git pull failed:', err);
+      respondThreaded(
+        say,
+        body,
+        `Something went wrong pulling the latest code. I hope you have ssh access.\n\`\`\`${err.message}\`\`\``,
+      );
+      return;
+    }
+
+    const SHA = childProcess
+      .execSync('git rev-parse HEAD')
+      .toString().trim();
+
+    const title = childProcess
+      .execSync('git show-branch --no-name HEAD')
+      .toString().trim();
+
+    if (response.summary.changes === 0) {
+      respondThreaded(say, body, `No changes detected. Already on latest commit: ${SHA} (${title})`);
+      return;
+    }
+
+    respondThreaded(say, body, `Pulled the latest changes, deploying ${SHA} (${title})...`);
+
+    // The restart itself may kill this process before it can report back
+    // here, so we leave a marker for the next boot to pick up and confirm.
+    writeReleaseMarker({
+      channel: body.event.channel,
+      threadTs: body.event.channel_type === 'im' ? undefined : (body.event.thread_ts || body.event.ts),
+      sha: SHA,
+      title,
+    });
+
+    const built = await rebuild({ body, say });
+
+    if (!built) {
+      // No restart is coming from this attempt, so don't leave a marker
+      // around to falsely confirm some later, unrelated restart.
+      clearReleaseMarker();
+      return;
+    }
+
+    // pm2's file-watch restart can't be relied on (it may not even be
+    // enabled on the running process, depending on how it was started), so
+    // explicitly restart ourselves under pm2 to actually run the new build.
+    if (process.env.pm_id) {
+      respondThreaded(say, body, 'Restarting...');
+      childProcess.execSync(`pm2 restart ${process.env.pm_id}`);
     } else {
-      // It seems like pm2 restarts the process before this can return if there
-      // is in fact a release, which means the user won't get feedback that a
-      // release happened.. I don't know what to do about that.
-
-      const SHA = childProcess
-        .execSync('git rev-parse HEAD')
-        .toString().trim();
-
-      const title = childProcess
-        .execSync('git show-branch --no-name HEAD')
-        .toString().trim();
-
-      if (response.summary.changes > 0) {
-        rebuild({ body, say });
-      } else {
-        out = `No changes deteced. Already on latest commit: ${SHA} (${title})`;
-        respondThreaded(say, body, out);
-      }
+      respondThreaded(say, body, 'Not running under pm2, so not restarting automatically. Restart the process manually to run the new build.');
+      clearReleaseMarker();
     }
   });
 };

--- a/src/utils/releaseMarker.ts
+++ b/src/utils/releaseMarker.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+// The rebuild triggered by ?release writes into ./built, which pm2 watches
+// and restarts the process on, so the process handling the release may be
+// killed before it can report success. This marker survives that restart so
+// the next boot can confirm the release actually completed.
+const MARKER_PATH = path.join(process.cwd(), '.release-marker.json');
+
+const writeReleaseMarker = (marker: {
+  channel: string;
+  threadTs?: string;
+  sha: string;
+  title: string;
+}) => {
+  fs.writeFileSync(MARKER_PATH, JSON.stringify(marker));
+};
+
+const clearReleaseMarker = () => {
+  if (fs.existsSync(MARKER_PATH)) {
+    fs.unlinkSync(MARKER_PATH);
+  }
+};
+
+const consumeReleaseMarker = () => {
+  if (!fs.existsSync(MARKER_PATH)) {
+    return null;
+  }
+
+  const marker = JSON.parse(fs.readFileSync(MARKER_PATH, 'utf8'));
+  clearReleaseMarker();
+  return marker;
+};
+
+export { writeReleaseMarker, clearReleaseMarker, consumeReleaseMarker };


### PR DESCRIPTION
?release could silently fail to take effect: pm2 watch on the live process wasn't enabled (despite ecosystem.config.js requesting it), so a successful rebuild never restarted the bot. It also had no error handling around npm install/npm run build, so a failed build could crash the whole process with no Slack feedback.

- rebuild.ts: catch install/build failures and report them instead of crashing the process
- release.ts: surface real git errors, report the deployed SHA, and explicitly pm2-restart the process instead of relying on file-watch
- releaseMarker.ts + app.ts: confirm the release completed on the next boot, since the restart can kill the process mid-report
- ecosystem.config.js: derive the pm2 process name from the directory so multiple cloned instances keep stable, distinct identities and `pm2 restart ecosystem.config.js` targets the right process instead of spawning a duplicate
- autoRelease.ts: post ?release into a configured channel every morning so merged dependabot updates get picked up automatically