### PR TITLE
?restart command

### DIFF
--- a/src/commandDispatcher.ts
+++ b/src/commandDispatcher.ts
@@ -16,6 +16,7 @@ import github from './commands/github';
 import pong from './commands/ping';
 import rebuild from './commands/rebuild';
 import release from './commands/release';
+import restartCommand from './commands/restart';
 import rocket from './commands/rocket';
 import search from './commands/search';
 import { bubble, scrabble, meow } from './commands/spell';
@@ -125,6 +126,10 @@ const COMMANDS = {
   release: {
     func: release,
     help: 'Fetches and deploys the most recent commit of this slackbot.',
+  },
+  restart: {
+    func: restartCommand,
+    help: 'Restarts the bot without pulling new code.',
   },
   scrabble: {
     func: scrabble,

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -5,6 +5,7 @@ import childProcess from 'child_process';
 import { respondThreaded } from '../utils/respond';
 import { clearReleaseMarker, writeReleaseMarker } from '../utils/releaseMarker';
 import rebuild from './rebuild';
+import restart from '../utils/restart';
 
 const options = {
   baseDir: process.cwd(),
@@ -63,10 +64,13 @@ const release = async ({ body, say }) => {
       return;
     }
 
-    // pm2 runs the bot via `tsx watch src/app.ts`, which already noticed
-    // the files the pull just changed and is restarting on its own — no
-    // need to trigger a restart ourselves.
     respondThreaded(say, body, 'Restarting...');
+
+    if (!restart({ body, say })) {
+      // No restart is coming from this attempt, so don't leave a marker
+      // around to falsely confirm some later, unrelated restart.
+      clearReleaseMarker();
+    }
   });
 };
 

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,0 +1,11 @@
+import { respondThreaded } from '../utils/respond';
+import restart from '../utils/restart';
+
+// Restarts the bot without pulling new code, e.g. to clear a stuck
+// tsx/esbuild watch state.
+const restartCommand = async ({ body, say }) => {
+  respondThreaded(say, body, 'Restarting...');
+  restart({ body, say });
+};
+
+export default restartCommand;

--- a/src/utils/restart.ts
+++ b/src/utils/restart.ts
@@ -11,7 +11,7 @@ import { respondThreaded } from './respond';
 // guarantee a truly fresh read. Returns whether the restart was issued.
 const restart = ({ body, say }): boolean => {
   try {
-    childProcess.execSync(`pm2 restart ${path.basename(process.cwd())}`);
+    childProcess.execFileSync('pm2', ['restart', path.basename(process.cwd())]);
     return true;
   } catch (error: any) {
     respondThreaded(say, body, `Restart failed.\n\`\`\`${error.message}\`\`\``);

--- a/src/utils/restart.ts
+++ b/src/utils/restart.ts
@@ -1,0 +1,22 @@
+import childProcess from 'child_process';
+import path from 'path';
+
+import { respondThreaded } from './respond';
+
+// Forces a full pm2-level restart rather than trusting tsx watch to notice
+// a file change on its own. tsx's own watch-triggered restart reuses its
+// long-lived esbuild transpile service, which we've seen serve a stale
+// compile of a file that was just changed on disk — killing the whole pm2
+// process tree (esbuild service included) is the only way we've found to
+// guarantee a truly fresh read. Returns whether the restart was issued.
+const restart = ({ body, say }): boolean => {
+  try {
+    childProcess.execSync(`pm2 restart ${path.basename(process.cwd())}`);
+    return true;
+  } catch (error: any) {
+    respondThreaded(say, body, `Restart failed.\n\`\`\`${error.message}\`\`\``);
+    return false;
+  }
+};
+
+export default restart;


### PR DESCRIPTION
- forces a full pm2 restart instead of trusting tsx watch's own restart-on-change, since tsx's esbuild transpile service has served a stale compile after a file changed on disk before
- ?release now goes through the same restart path after a successful pull, instead of just assuming tsx watch caught it